### PR TITLE
Tweak a link and a typo

### DIFF
--- a/src/exercise/06.js
+++ b/src/exercise/06.js
@@ -65,7 +65,7 @@ function useToggle({
   //
   // 💰 Sorry if Olivia the Owl is cryptic. Here's what you need to do for that onChange call:
   // `onChange(reducer({...state, on}, action), action)`
-  // 💰 Also note that user's don't *have* to pass an `onChange` prop (it's not required)
+  // 💰 Also note that users don't *have* to pass an `onChange` prop (it's not required)
   // so keep that in mind when you call it! How could you avoid calling it if it's not passed?
 
   // make these call `dispatchWithOnChange` instead

--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -89,8 +89,7 @@ control the state of `on` and call the `onChange` with the suggested changes.
 [Production deploy](http://advanced-react-patterns.netlify.app/isolated/final/06.extra-1.js)
 
 Take a look at the example in `./src/examples/warnings.js` (you can pull it up
-at
-[/isolated/examples/warnings.js](http://localhost:3000/isolated/examples/warnings.js)).
+at [/isolated/examples/warnings.js](/isolated/examples/warnings.js)).
 
 Notice the warnings when you click the buttons. You should see the following
 warnings all related to controlled inputs:


### PR DESCRIPTION
Two quickie changes:
* Fix a reference link for folks developing on remote systems f94841764b6a877ce6fb73ef19bcdc93f19f9640
* Fix a little typo ("user's" should be "users") 79c9c1acbe16c61c227d6f51c61b623ec1efa5c5