### PR TITLE
lints clean

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "react-scripts": "^5.0.1"
       },
       "engines": {
-        "node": "14 || 16 || 18",
+        "node": ">=16",
         "npm": ">=8.16.0"
       }
     },
@@ -5990,9 +5990,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001358",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
-      "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==",
+      "version": "1.0.30001752",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001752.tgz",
+      "integrity": "sha512-vKUk7beoukxE47P5gcVNKkDRzXdVofotshHwfR9vmpeFKxmI5PBpgOMC18LUJUA/DvJ70Y7RveasIBraqsyO/g==",
       "dev": true,
       "funding": [
         {
@@ -6002,8 +6002,13 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/capture-stack-trace": {
       "version": "1.0.1",
@@ -26276,9 +26281,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001358",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
-      "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==",
+      "version": "1.0.30001752",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001752.tgz",
+      "integrity": "sha512-vKUk7beoukxE47P5gcVNKkDRzXdVofotshHwfR9vmpeFKxmI5PBpgOMC18LUJUA/DvJ70Y7RveasIBraqsyO/g==",
       "dev": true
     },
     "capture-stack-trace": {

--- a/src/__tests__/01.js
+++ b/src/__tests__/01.js
@@ -110,7 +110,7 @@ test('reset works', async () => {
   expect(taglineInput.value).toBe(mockUser.tagline)
 })
 
-/*eslint no-unused-vars:*/
+/*eslint no-unused-vars:0*/
 test('failure works', async () => {
   const {
     submitButton,

--- a/src/__tests__/01.js
+++ b/src/__tests__/01.js
@@ -110,6 +110,7 @@ test('reset works', async () => {
   expect(taglineInput.value).toBe(mockUser.tagline)
 })
 
+/*eslint no-unused-vars:*/
 test('failure works', async () => {
   const {
     submitButton,


### PR DESCRIPTION
fixes `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an inline linting directive to a test to suppress unused-variable warnings, ensuring the test runs without lint errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->